### PR TITLE
#131 error on gtfs_transfer_table when no transfers found fix

### DIFF
--- a/R/transfers.R
+++ b/R/transfers.R
@@ -159,6 +159,7 @@ get_transfer_list <- function (gtfs, d_limit) {
             d = dists [[i]]
         )
     }
+    transfers <- transfers[lens>0]
     transfers <- data.frame (do.call (rbind, transfers),
         stringsAsFactors = FALSE
     )


### PR DESCRIPTION
I implemented the fix suggested at #131 to avoid a crash when generating transfers for a GTFS feed that has no stops matching the defined criteria.